### PR TITLE
Prevent incorrect results when multiple pings are running at the same time

### DIFF
--- a/icmplib/sockets.py
+++ b/icmplib/sockets.py
@@ -276,12 +276,15 @@ class ICMPSocket:
         except OSError as err:
             raise ICMPSocketError(str(err))
 
-    def receive(self):
+    def receive(self, match_source_addr=None):
         '''
         Receive a reply from a host.
 
         This method can be called multiple times if you expect several
         responses (as with a broadcast address).
+
+        :type match_source_addr: str
+        :param match_source_addr: (Optional) The expected source address of the response.
 
         :raises TimeoutExceeded: If no response is received before the
             timeout defined in the request.
@@ -309,6 +312,9 @@ class ICMPSocket:
         try:
             while True:
                 packet, address, port = self._socket.receive()
+                if match_source_addr and address != match_source_addr:
+                    continue
+
                 reply_time = time()
 
                 if reply_time > timeout:

--- a/icmplib/utils.py
+++ b/icmplib/utils.py
@@ -24,6 +24,7 @@
     <https://www.gnu.org/licenses/>.
 '''
 
+import socket
 from os import getpid
 from random import choice
 
@@ -57,3 +58,11 @@ def is_ipv6_address(address):
 
     '''
     return ':' in address
+
+
+def resolv_host_ipv4(host_or_address):
+    '''
+    Take an host or ip address and returns the ip address.
+
+    '''
+    return socket.gethostbyname(host_or_address)


### PR DESCRIPTION
Solves https://github.com/home-assistant/core/issues/39827

Since the socket would listen for any icmp traffic coming back, multiple
pings that ran at the same time would receive responses from hosts that
were unexpected so it would appear hosts were online when they were
actually down.