### PR TITLE
Fixes #16: avg_rtt should be divided by packets_received

### DIFF
--- a/icmplib/traceroute.py
+++ b/icmplib/traceroute.py
@@ -170,6 +170,9 @@ def traceroute(address, count=3, interval=0.05, timeout=2, id=PID,
 
             if fast_mode:
                 break
+                
+        if packets_received:
+            avg_rtt /= packets_received
 
         if reply:
             hop = Hop(


### PR DESCRIPTION
This PR should fix #16, by making sure avt_rtt is divided by packets_received if it's not None.