### PR TITLE
Async ping support

### DIFF
--- a/icmplib/__init__.py
+++ b/icmplib/__init__.py
@@ -29,7 +29,7 @@
 
 from .sockets import ICMPv4Socket, ICMPv6Socket
 from .models import ICMPRequest, ICMPReply, Host, Hop
-from .ping import ping
+from .ping import ping, aioping
 from .traceroute import traceroute
 from .exceptions import *
 from .utils import PID, resolve, is_ipv4_address, is_ipv6_address

--- a/icmplib/ping.py
+++ b/icmplib/ping.py
@@ -193,12 +193,18 @@ async def aioping(address, count=4, interval=1, timeout=2, packet_id=0, source=N
 
     Same API as `ping`.
     Usage::
-        >>> from icmplib import ping
-        >>> host = await ping('1.1.1.1')
-        >>> host.avg_rtt
+        >>> import asyncio
+        >>> from icmplib import aioping
+        >>> asyncio.run(aioping('1.1.1.1'))
+        Or
+        >>> async def my_func():
+        >>>     host = await aioping('1.1.1.1')
+        >>>     host.avg_rtt
+        >>>     host.is_alive
+        >>> asyncio.run(my_func())
         13.2
-        >>> host.is_alive
         True
+
     See the `Host` class for details.
     """
     address = resolve(address)


### PR DESCRIPTION
Draft, up for suggestions or changes. Also feel free to close if you think this is out of scope. 

Notes:
* I've changed `id` to be `packet_id` to not shadow outer scope
* I've changed `socket` to be named `sock` to not shadow outer scope
* PID can not be used as an ID for async, a `random.randint()` or similar solution must be used. Can it be a string? Can we use `uuid.uuid4().hex`? 
* Uses `IPv6Address` builtin Python function from the `ipaddress` library instead of regex.

Utilizes [`asyncio.run_in_executor`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor) to make it awaitable. 

Closes #24 