### PR TITLE
Add interface binding to ICMP sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+- Add `interface` parameter to bind sockets to a specific network interface.
+  - Available in `ping`, `multiping`, `traceroute`, `async_ping`, and `async_multiping` functions.
+  - Available in `ICMPv4Socket` and `ICMPv6Socket` classes.
+  - Only available on Unix systems. Ignored on Windows.
+
 ## [v3.0.4](https://github.com/ValentinBELYN/icmplib/releases/tag/v3.0.4) - 2023-10-10
 - Fix licensing inconsistencies.
 - Add support for the latest versions of Python.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - Add `interface` parameter to bind sockets to a specific network interface.
   - Available in `ping`, `multiping`, `traceroute`, `async_ping`, and `async_multiping` functions.
   - Available in `ICMPv4Socket` and `ICMPv6Socket` classes.
-  - Only available on Unix systems. Ignored on Windows.
+  - Only available on Linux. Ignored on macOS and Windows.
 
 ## [v3.0.4](https://github.com/ValentinBELYN/icmplib/releases/tag/v3.0.4) - 2023-10-10
 - Fix licensing inconsistencies.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Use the built-in functions or build your own, you have the choice!
 Send ICMP Echo Request packets to a network host.
 
 ```python
-ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, **kwargs)
+ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters
@@ -152,6 +152,15 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
 
   - Type: `bool`
   - Default: `True`
+
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
+  - Default: `None`
 
 - `payload`
 
@@ -248,7 +257,7 @@ True
 Send ICMP Echo Request packets to several network hosts.
 
 ```python
-multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, **kwargs)
+multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters
@@ -311,6 +320,15 @@ multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, sour
 
   - Type: `bool`
   - Default: `True`
+
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
+  - Default: `None`
 
 - `payload`
 
@@ -549,7 +567,7 @@ Send ICMP Echo Request packets to a network host.
 *This function is non-blocking.*
 
 ```python
-async_ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, **kwargs)
+async_ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters, return value and exceptions
@@ -579,7 +597,7 @@ Send ICMP Echo Request packets to several network hosts.
 *This function is non-blocking.*
 
 ```python
-async_multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, **kwargs)
+async_multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters, return value and exceptions

--- a/README.md
+++ b/README.md
@@ -155,9 +155,11 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
 
 - `interface`
 
-  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `lo`, `eth0`, `wlan0`). By default, the socket is not bound to a specific interface.
 
   *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`
@@ -323,9 +325,11 @@ multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, sour
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `lo`, `eth0`, `wlan0`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
 
   - Type: `str`
   - Default: `None`

--- a/docs/2-functions.md
+++ b/docs/2-functions.md
@@ -69,6 +69,15 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
   - Type: `bool`
   - Default: `True`
 
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
+  - Default: `None`
+
 - `payload`
 
   The payload content in bytes. A random payload is used by default.
@@ -164,7 +173,7 @@ True
 Send ICMP Echo Request packets to several network hosts.
 
 ```python
-multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, **kwargs)
+multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters
@@ -227,6 +236,15 @@ multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, sour
 
   - Type: `bool`
   - Default: `True`
+
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
+  - Default: `None`
 
 - `payload`
 
@@ -306,7 +324,7 @@ The Internet is a large and complex aggregation of network hardware, connected t
 *This function requires root privileges to run.*
 
 ```python
-traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1, max_hops=30, fast=False, id=None, source=None, family=None, **kwargs)
+traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1, max_hops=30, fast=False, id=None, source=None, family=None, interface=None, **kwargs)
 ```
 
 #### Parameters
@@ -378,6 +396,15 @@ traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1, max_hops=30,
   The address family if a hostname or FQDN is specified. Can be set to `4` for IPv4 or `6` for IPv6 addresses. By default, this function searches for IPv4 addresses first before searching for IPv6 addresses.
 
   - Type: `int`
+  - Default: `None`
+
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
   - Default: `None`
 
 - `payload`
@@ -465,7 +492,7 @@ Send ICMP Echo Request packets to a network host.
 *This function is non-blocking.*
 
 ```python
-async_ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, **kwargs)
+async_ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters, return value and exceptions
@@ -495,7 +522,7 @@ Send ICMP Echo Request packets to several network hosts.
 *This function is non-blocking.*
 
 ```python
-async_multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, **kwargs)
+async_multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, source=None, family=None, privileged=True, interface=None, **kwargs)
 ```
 
 #### Parameters, return value and exceptions

--- a/docs/2-functions.md
+++ b/docs/2-functions.md
@@ -71,9 +71,9 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
 
   - Type: `str`
   - Default: `None`
@@ -239,9 +239,9 @@ multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, sour
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
 
   - Type: `str`
   - Default: `None`
@@ -400,9 +400,9 @@ traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1, max_hops=30,
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
 
   - Type: `str`
   - Default: `None`

--- a/docs/2-functions.md
+++ b/docs/2-functions.md
@@ -74,6 +74,8 @@ ping(address, count=4, interval=1, timeout=2, id=None, source=None, family=None,
   The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
   *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`
@@ -242,6 +244,8 @@ multiping(addresses, count=2, interval=0.5, timeout=2, concurrent_tasks=50, sour
   The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
   *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`
@@ -403,6 +407,8 @@ traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1, max_hops=30,
   The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
   *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`

--- a/docs/3-sockets.md
+++ b/docs/3-sockets.md
@@ -176,9 +176,9 @@ ICMPv4Socket(address=None, privileged=True, interface=None)
 
 - `interface`
 
-  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+  The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
-  *Only available on Unix systems. Ignored on Windows.*
+  *Only available on Linux. Ignored on macOS and Windows.*
 
   - Type: `str`
   - Default: `None`

--- a/docs/3-sockets.md
+++ b/docs/3-sockets.md
@@ -153,7 +153,7 @@ ICMPReply(source, family, id, sequence, type, code, bytes_received, time)
 Class for sending and receiving ICMPv4 packets.
 
 ```python
-ICMPv4Socket(address=None, privileged=True)
+ICMPv4Socket(address=None, privileged=True, interface=None)
 ```
 
 #### Parameters
@@ -174,9 +174,18 @@ ICMPv4Socket(address=None, privileged=True)
   - Type: `bool`
   - Default: `True`
 
+- `interface`
+
+  The network interface to bind to (e.g., 'eth0', 'wlan0'). By default, the socket is not bound to a specific interface.
+
+  *Only available on Unix systems. Ignored on Windows.*
+
+  - Type: `str`
+  - Default: `None`
+
 #### Methods
 
-- `__init__(address=None, privileged=True)`
+- `__init__(address=None, privileged=True, interface=None)`
 
   *Constructor. Automatically called: do not call it directly.*
 
@@ -280,7 +289,7 @@ ICMPv4Socket(address=None, privileged=True)
 Class for sending and receiving ICMPv6 packets.
 
 ```python
-ICMPv6Socket(address=None, privileged=True)
+ICMPv6Socket(address=None, privileged=True, interface=None)
 ```
 
 #### Methods and properties

--- a/docs/3-sockets.md
+++ b/docs/3-sockets.md
@@ -179,6 +179,8 @@ ICMPv4Socket(address=None, privileged=True, interface=None)
   The network interface to bind to (e.g., `'lo'`, `'eth0'`, `'wlan0'`). By default, the socket is not bound to a specific interface.
 
   *Only available on Linux. Ignored on macOS and Windows.*
+  
+  *This function requires root privileges to run.*
 
   - Type: `str`
   - Default: `None`

--- a/examples/interface_ping.py
+++ b/examples/interface_ping.py
@@ -1,0 +1,46 @@
+'''
+    icmplib
+    ~~~~~~~
+
+    Easily forge ICMP packets and make your own ping and traceroute.
+
+        https://github.com/ValentinBELYN/icmplib
+
+    :copyright: Copyright 2017-2023 Valentin BELYN.
+    :license: GNU LGPLv3, see the LICENSE for details.
+
+    ~~~~~~~
+
+    Example: interface binding
+'''
+
+from icmplib import ping, multiping
+
+
+# Ping with interface binding
+# Bind to loopback interface
+host = ping('127.0.0.1', count=4, interface='lo')
+
+print(host.is_alive)
+# True
+
+
+# Ping via specific network interface (e.g., eth0, wlan0)
+# Replace 'eth0' with your actual network interface name
+# You can list interfaces with: ip link show (Linux) or ifconfig (macOS)
+
+# Uncomment and adjust the interface name to test:
+# host = ping('8.8.8.8', count=4, interface='eth0')
+# print(host.is_alive)
+# True
+
+
+# Multiping with interface binding
+addresses = ['127.0.0.1', '::1']
+hosts = multiping(addresses, count=2, interface='lo')
+
+for host in hosts:
+    print(host.address, host.is_alive)
+
+# 127.0.0.1 True
+# ::1 True

--- a/examples/interface_ping.py
+++ b/examples/interface_ping.py
@@ -18,16 +18,16 @@ from icmplib import ping, multiping
 
 
 # Ping with interface binding
-# Bind to loopback interface
+# Bind to loopback interface (Linux only)
 host = ping('127.0.0.1', count=4, interface='lo')
 
 print(host.is_alive)
 # True
 
 
-# Ping via specific network interface (e.g., eth0, wlan0)
-# Replace 'eth0' with your actual network interface name
-# You can list interfaces with: ip link show (Linux) or ifconfig (macOS)
+# Ping via specific network interface (Linux only)
+# Common interface names: lo, eth0, wlan0, ens33, etc.
+# You can list interfaces with: ip link show
 
 # Uncomment and adjust the interface name to test:
 # host = ping('8.8.8.8', count=4, interface='eth0')
@@ -35,7 +35,7 @@ print(host.is_alive)
 # True
 
 
-# Multiping with interface binding
+# Multiping with interface binding (Linux only)
 addresses = ['127.0.0.1', '::1']
 hosts = multiping(addresses, count=2, interface='lo')
 

--- a/icmplib/multiping.py
+++ b/icmplib/multiping.py
@@ -33,7 +33,7 @@ from .ping import async_ping
 
 async def async_multiping(addresses, count=2, interval=0.5, timeout=2,
         concurrent_tasks=50, source=None, family=None, privileged=True,
-        **kwargs):
+        interface=None, **kwargs):
     '''
     Send ICMP Echo Request packets to several network hosts.
 
@@ -82,6 +82,11 @@ async def async_multiping(addresses, count=2, interval=0.5, timeout=2,
         root privileges and let the kernel handle ICMP headers.
         Default to True.
         Only available on Unix systems. Ignored on Windows.
+
+    :type interface: str, optional
+    :param interface: The network interface to bind to (e.g., 'eth0',
+        'wlan0'). By default, the socket is not bound to a specific
+        interface. Only available on Unix systems. Ignored on Windows.
 
     Advanced (**kwags):
 
@@ -153,6 +158,7 @@ async def async_multiping(addresses, count=2, interval=0.5, timeout=2,
                 source=source,
                 family=family,
                 privileged=privileged,
+                interface=interface,
                 **kwargs))
 
         tasks.append(task)
@@ -165,7 +171,7 @@ async def async_multiping(addresses, count=2, interval=0.5, timeout=2,
 
 def multiping(addresses, count=2, interval=0.5, timeout=2,
         concurrent_tasks=50, source=None, family=None, privileged=True,
-        **kwargs):
+        interface=None, **kwargs):
     '''
     Send ICMP Echo Request packets to several network hosts.
 
@@ -212,6 +218,12 @@ def multiping(addresses, count=2, interval=0.5, timeout=2,
         root privileges and let the kernel handle ICMP headers.
         Default to True.
         Only available on Unix systems. Ignored on Windows.
+
+    :type interface: str, optional
+    :param interface: The network interface to bind to (e.g., 'eth0',
+        'wlan0'). By default, the socket is not bound to a specific
+        interface. Only available on Unix systems. Ignored on Windows.
+
 
     Advanced (**kwags):
 
@@ -274,4 +286,5 @@ def multiping(addresses, count=2, interval=0.5, timeout=2,
             source=source,
             family=family,
             privileged=privileged,
+            interface=interface,
             **kwargs))

--- a/icmplib/multiping.py
+++ b/icmplib/multiping.py
@@ -86,7 +86,7 @@ async def async_multiping(addresses, count=2, interval=0.5, timeout=2,
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
     Advanced (**kwags):
 
@@ -222,7 +222,7 @@ def multiping(addresses, count=2, interval=0.5, timeout=2,
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
 
     Advanced (**kwags):

--- a/icmplib/ping.py
+++ b/icmplib/ping.py
@@ -36,7 +36,7 @@ from .utils import *
 
 
 def ping(address, count=4, interval=1, timeout=2, id=None, source=None,
-        family=None, privileged=True, **kwargs):
+        family=None, privileged=True, interface=None, **kwargs):
     '''
     Send ICMP Echo Request packets to a network host.
 
@@ -81,6 +81,11 @@ def ping(address, count=4, interval=1, timeout=2, id=None, source=None,
         root privileges and let the kernel handle ICMP headers.
         Default to True.
         Only available on Unix systems. Ignored on Windows.
+
+    :type interface: str, optional
+    :param interface: The network interface to bind to (e.g., 'eth0',
+        'wlan0'). By default, the socket is not bound to a specific
+        interface. Only available on Unix systems. Ignored on Windows.
 
     Advanced (**kwags):
 
@@ -166,7 +171,7 @@ def ping(address, count=4, interval=1, timeout=2, id=None, source=None,
 
 
 async def async_ping(address, count=4, interval=1, timeout=2, id=None,
-        source=None, family=None, privileged=True, **kwargs):
+        source=None, family=None, privileged=True, interface=None, **kwargs):
     '''
     Send ICMP Echo Request packets to a network host.
 
@@ -213,6 +218,12 @@ async def async_ping(address, count=4, interval=1, timeout=2, id=None,
         root privileges and let the kernel handle ICMP headers.
         Default to True.
         Only available on Unix systems. Ignored on Windows.
+
+    :type interface: str, optional
+    :param interface: The network interface to bind to (e.g., 'eth0',
+        'wlan0'). By default, the socket is not bound to a specific
+        interface. Only available on Unix systems. Ignored on Windows.
+
 
     Advanced (**kwags):
 

--- a/icmplib/ping.py
+++ b/icmplib/ping.py
@@ -143,7 +143,7 @@ def ping(address, count=4, interval=1, timeout=2, id=None, source=None,
     packets_sent = 0
     rtts = []
 
-    with _Socket(source, privileged) as sock:
+    with _Socket(source, privileged, interface) as sock:
         for sequence in range(count):
             if sequence > 0:
                 sleep(interval)
@@ -282,7 +282,7 @@ async def async_ping(address, count=4, interval=1, timeout=2, id=None,
     packets_sent = 0
     rtts = []
 
-    with AsyncSocket(_Socket(source, privileged)) as sock:
+    with AsyncSocket(_Socket(source, privileged, interface)) as sock:
         for sequence in range(count):
             if sequence > 0:
                 await asyncio.sleep(interval)

--- a/icmplib/ping.py
+++ b/icmplib/ping.py
@@ -85,7 +85,7 @@ def ping(address, count=4, interval=1, timeout=2, id=None, source=None,
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
     Advanced (**kwags):
 
@@ -222,7 +222,7 @@ async def async_ping(address, count=4, interval=1, timeout=2, id=None,
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
 
     Advanced (**kwags):

--- a/icmplib/sockets.py
+++ b/icmplib/sockets.py
@@ -170,9 +170,12 @@ class ICMPSocket:
         # SO_BINDTODEVICE requires CAP_NET_RAW capability on Linux
         # Interface name must be encoded to bytes
         try:
+            # Try to get SO_BINDTODEVICE constant, fallback to 25 for compatibility
+            SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
             self._sock.setsockopt(
                 socket.SOL_SOCKET,
                 25,  # SO_BINDTODEVICE
+                SO_BINDTODEVICE,
                 interface.encode(),
             )
         except (OSError, AttributeError) as err:

--- a/icmplib/sockets.py
+++ b/icmplib/sockets.py
@@ -54,7 +54,7 @@ class ICMPSocket:
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
     :raises SocketPermissionError: If the privileges are insufficient to
         create the socket.
@@ -159,13 +159,14 @@ class ICMPSocket:
         '''
         Bind the socket to a specific network interface.
 
-        Only available on Unix systems. Ignored on Windows.
+        Only available on Linux. Ignored on macOS and Windows.
 
         '''
-        # Not available on Windows
-        if PLATFORM_WINDOWS:
+        # Not available on Windows or macOS
+        if PLATFORM_WINDOWS or PLATFORM_MACOS:
             return
 
+        # Linux uses SO_BINDTODEVICE
         # SO_BINDTODEVICE requires CAP_NET_RAW capability on Linux
         # Interface name must be encoded to bytes
         try:

--- a/icmplib/sockets.py
+++ b/icmplib/sockets.py
@@ -64,7 +64,7 @@ class ICMPSocket:
         socket.
 
     '''
-    __slots__ = '_sock', '_address', '_privileged', '_interface'
+    __slots__ = '_sock', '_address', '_privileged'
 
     _IP_VERSION              = -1
     _ICMP_HEADER_OFFSET      = -1
@@ -82,7 +82,6 @@ class ICMPSocket:
     def __init__(self, address=None, privileged=True, interface=None):
         self._sock = None
         self._address = address
-        self._interface = interface
 
         # The Linux kernel allows unprivileged users to use datagram
         # sockets (SOCK_DGRAM) to send ICMP requests. This feature is

--- a/icmplib/sockets.py
+++ b/icmplib/sockets.py
@@ -169,16 +169,15 @@ class ICMPSocket:
         # Linux uses SO_BINDTODEVICE
         # SO_BINDTODEVICE requires CAP_NET_RAW capability on Linux
         # Interface name must be encoded to bytes
+        # Try to get SO_BINDTODEVICE constant, fallback to 25 for compatibility
+        SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
         try:
-            # Try to get SO_BINDTODEVICE constant, fallback to 25 for compatibility
-            SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
             self._sock.setsockopt(
                 socket.SOL_SOCKET,
-                25,  # SO_BINDTODEVICE
                 SO_BINDTODEVICE,
-                interface.encode(),
+                interface.encode("ascii"),
             )
-        except (OSError, AttributeError) as err:
+        except (OSError) as err:
             raise ICMPSocketError(f"Cannot bind to interface {interface}: {err}")
 
     def _checksum(self, data):

--- a/icmplib/traceroute.py
+++ b/icmplib/traceroute.py
@@ -36,7 +36,7 @@ from .utils import *
 
 def traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1,
         max_hops=30, fast=False, id=None, source=None, family=None,
-        **kwargs):
+        interface=None, **kwargs):
     '''
     Determine the route to a destination host.
 
@@ -94,6 +94,11 @@ def traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1,
         Can be set to `4` for IPv4 or `6` for IPv6 addresses. By default,
         this function searches for IPv4 addresses first before searching
         for IPv6 addresses.
+
+    :type interface: str, optional
+    :param interface: The network interface to bind to (e.g., 'eth0',
+        'wlan0'). By default, the socket is not bound to a specific
+        interface. Only available on Unix systems. Ignored on Windows.
 
     Advanced (**kwags):
 
@@ -167,7 +172,7 @@ def traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1,
     host_reached = False
     hops = []
 
-    with _Socket(source) as sock:
+    with _Socket(source, True, interface) as sock:
         while not host_reached and ttl <= max_hops:
             reply = None
             packets_sent = 0

--- a/icmplib/traceroute.py
+++ b/icmplib/traceroute.py
@@ -98,7 +98,7 @@ def traceroute(address, count=2, interval=0.05, timeout=2, first_hop=1,
     :type interface: str, optional
     :param interface: The network interface to bind to (e.g., 'eth0',
         'wlan0'). By default, the socket is not bound to a specific
-        interface. Only available on Unix systems. Ignored on Windows.
+        interface. Only available on Linux. Ignored on macOS and Windows.
 
     Advanced (**kwags):
 


### PR DESCRIPTION
### Summary
This PR adds the ability to bind ICMP sockets (only on linux) to specific network interfaces.

### Changes

#### Core Implementation
- **Sockets**: Added `interface` parameter to `ICMPSocket`, `ICMPv4Socket`, and `ICMPv6Socket` classes
  - Implements binding via `SO_BINDTODEVICE` socket option on Unix systems (requires root)
  - Automatically ignored on Windows for cross-platform compatibility
  
- **Functions**: Added `interface` parameter to all public functions:
  - `ping()`
  - `multiping()` 
  - `traceroute()`
  - `async_ping()`
  - `async_multiping()`

#### Documentation
Updated:
- API Documentation
- README
- CHANGELOG
- Example script

### Use Cases
Our infrastructure nodes have private and public interfaces. We perform end-to-end testing to ensure that the private interface is functioning correctly; if not, we configure the routes to use the external interface instead. Without interface binding, icmplib always uses the working interface, making it impossible to test a specific interface independently.

This will also fix:
* https://github.com/ValentinBELYN/icmplib/issues/32

### Platform Support
- **Linux**: Full support via `SO_BINDTODEVICE`
- **macOS**: Parameter accepted but ignored
- **Windows**: Parameter accepted but ignored

### Example Usage
```python
from icmplib import ping

# Bind to loopback interface
host = ping('127.0.0.1', interface='lo')

# Bind to ethernet interface
host = ping('8.8.8.8', interface='eth0')
```

### Backward Compatibility
This change is fully backward compatible. The `interface` parameter is optional and defaults to `None`.

### Testing
- Tested on Linux (Ubuntu 24.04) with various network interfaces